### PR TITLE
Allow to get the right context

### DIFF
--- a/jquery.autoSave.js
+++ b/jquery.autoSave.js
@@ -16,7 +16,7 @@
                     localStorage.setItem("autoSave", $context);
                 }
                 timer = setTimeout(function() {
-                    callback();
+                    callback.call($this);
                 }, delay);
             });
         });


### PR DESCRIPTION
Allow to get the right context in the callback function to access the current element.